### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CCAdsPlayView
 简单的，体验友好的广告轮播控件
 
-#####特色
+##### 特色
 - 异步下载使用SDWebImage
 - 循环时间：默认5秒，可自定义,（设置0则不滚动）
 - 滚动点：  默认居中，可设置居右或者直接隐藏
@@ -9,7 +9,7 @@
 - 注：暂只支持code方式创建
 
 
-#####使用API
+##### 使用API
         CCAdsPlayView *apView = [CCAdsPlayView adsPlayViewWithFrame:CGRectMake(0, 0,screenWidth, screenHeight) imageGroup:imgArray];
         //apView.pageContolAliment = CCPageContolAlimentRight;
         //apView.animationDuration = 1.;
@@ -22,4 +22,4 @@
         }];
     
     
-####觉得好用的话，客官请给星哦，感谢。
+#### 觉得好用的话，客官请给星哦，感谢。


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
